### PR TITLE
Fix size hints, add NoMinSize and NoMaxSize, clarify ResizeWindows

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Name                  | Values  | Description
 `ConfineMouse`        | `0`/`1` | Boolean - Confine the mouse to the program's window while it is focused. Focus must then be changed with the keyboard.
 `NoPrimarySelection`  | `0`/`1` | Boolean - Disable getting (pasting) or setting (copying) the `PRIMARY` X selection (usually done by middle clicks).
 `NoResolutionChange`  | `0`/`1` | Boolean - Disable setting screen resolution.
+`NoMinSize`           | `0`/`1` | Boolean - Disable minimum window size restriction.
+`NoMaxSize`           | `0`/`1` | Boolean - Disable maximum window size restriction.
 `MainX`/`Y`           | Integer | The X11 coordinates of your primary monitor (or left-top-most monitor to be used for games)
 `MainW`/`H`           | Integer | The resolution of your primary monitor (or total resolution of monitors to be used for games)
 `DesktopW`/`H`        | Integer | The resolution of your desktop (all monitors combined)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Name                  | Values  | Description
 `Enable`              | `0`/`1` | Boolean - Intercept the X11 connection (required for any other settings to have any effect)
 `JoinMST`             | `0`/`1` | Boolean - For monitors which present each half as one MST panel, join them and present them as one monitor to the application
 `MaskOtherMonitors`   | `0`/`1` | Boolean - Whether to hide the presence of other monitors from the application
-`ResizeWindows`       | `0`/`1` | Boolean - Whether to forcibly change the size of windows that span too many monitors
+`ResizeWindows`       | `0`/`1` | Boolean - Whether to forcibly change the size of windows whose width is equal to `DesktopW`
 `ResizeAll`           | `0`/`1` | Boolean - Resize (stretch) all windows, not just those matching the size of one MST panel
 `MoveWindows`         | `0`/`1` | Boolean - Whether to forcibly move windows created at (0,0) to the primary monitor
 `Fork`                | `0`/`1` | Boolean - Move processing to a separate forked process.

--- a/common.c
+++ b/common.c
@@ -299,9 +299,6 @@ static void fixSize(
 	CARD16* width,
 	CARD16* height)
 {
-	if (!config.resizeWindows)
-		return;
-
 	if (config.resizeAll && *width >= 640 && *height >= 480)
 	{
 		*width = config.mainW;
@@ -309,7 +306,7 @@ static void fixSize(
 	}
 
 	// Fix windows spanning multiple monitors
-	if (*width == config.desktopW)
+	if (config.resizeWindows && *width == config.desktopW)
 		*width = config.mainW;
 
 	// Fix spanning one half of a MST monitor

--- a/common.c
+++ b/common.c
@@ -124,6 +124,8 @@ struct Config
 	char noMouseGrab;
 	char noKeyboardGrab;
 	char noPrimarySelection;
+	char noMinSize;
+	char noMaxSize;
 	char dumb; // undocumented - act as a dumb pipe, nothing more
 	char confineMouse;
 	char noResolutionChange;
@@ -241,6 +243,8 @@ static void readConfig(const char* fn)
 		PARSE_INT(noMouseGrab)
 		PARSE_INT(noKeyboardGrab)
 		PARSE_INT(noPrimarySelection)
+		PARSE_INT(noMinSize)
+		PARSE_INT(noMaxSize)
 		PARSE_INT(dumb)
 		PARSE_INT(confineMouse)
 		PARSE_INT(noResolutionChange)
@@ -983,6 +987,16 @@ static bool handleClientData(X11ConnData* data)
 
 				fixSize((CARD16*)&hints->maxWidth, (CARD16*)&hints->maxHeight);
 				fixSize((CARD16*)&hints->baseWidth, (CARD16*)&hints->baseHeight);
+				if (config.noMinSize) {
+					hints->flags &= ~PMinSize;
+					hints->minWidth = 0;
+					hints->minHeight = 0;
+				}
+				if (config.noMaxSize) {
+					hints->flags &= ~PMaxSize;
+					hints->maxWidth = 0;
+					hints->maxHeight = 0;
+				}
 				debugPropSizeHints(hints);
 			}
 			break;

--- a/common.c
+++ b/common.c
@@ -749,6 +749,38 @@ enum
 	Note_NV_GLX,
 };
 
+// definition stolen from libX11/src/Xatomtype.h
+typedef struct {
+    CARD32 flags;
+    CARD32 x, y, width, height;
+    CARD32 minWidth, minHeight;
+    CARD32 maxWidth, maxHeight;
+    CARD32 widthInc, heightInc;
+    CARD32 minAspectX, minAspectY;
+    CARD32 maxAspectX, maxAspectY;
+    CARD32 baseWidth,baseHeight;
+    CARD32 winGravity;
+} xPropSizeHints;
+
+static void debugPropSizeHints(xPropSizeHints* hints) {
+	log_debug2(
+		"PropSizeHints: flags=0x%"PRIxCARD32" pos=%"PRIuCARD32"x%"PRIuCARD32" size=%"PRIuCARD32"x%"PRIuCARD32
+		" min_size=%"PRIuCARD32"x%"PRIuCARD32" base_size=%"PRIuCARD32"x%"PRIuCARD32
+		" max_size=%"PRIuCARD32"x%"PRIuCARD32" size_inc=%"PRIuCARD32"x%"PRIuCARD32
+		" min_aspect=%"PRIuCARD32"x%"PRIuCARD32" max_aspect=%"PRIuCARD32"x%"PRIuCARD32" win_gravity=%"PRIuCARD32"\n",
+		hints->flags,
+		hints->x, hints->y,
+		hints->width, hints->height,
+		hints->minWidth, hints->minHeight,
+		hints->baseWidth, hints->baseHeight,
+		hints->maxWidth, hints->maxHeight,
+		hints->widthInc, hints->heightInc,
+		hints->minAspectX, hints->minAspectY,
+		hints->maxAspectX, hints->maxAspectY,
+		hints->winGravity
+	);
+}
+
 static CARD16 injectRequest(X11ConnData *data, void* buf, size_t size)
 {
 	struct Connection conn = {};
@@ -944,10 +976,14 @@ static bool handleClientData(X11ConnData* data)
 			log_debug2(" XChangeProperty: property=%"PRIuCARD32" type=%"PRIuCARD32" format=%d)\n", req->property, req->type, req->format);
 			if (req->type == XA_WM_SIZE_HINTS)
 			{
-				XSizeHints* hints = (XSizeHints*)(data->buf + sz_xChangePropertyReq);
+				xPropSizeHints* hints = (xPropSizeHints*)(data->buf + sz_xChangePropertyReq);
+
+				debugPropSizeHints(hints);
 				fixCoords((INT16*)&hints->x, (INT16*)&hints->y, (CARD16*)&hints->width, (CARD16*)&hints->height);
-				fixSize((CARD16*)&hints->max_width, (CARD16*)&hints->max_height);
-				fixSize((CARD16*)&hints->base_width, (CARD16*)&hints->base_height);
+
+				fixSize((CARD16*)&hints->maxWidth, (CARD16*)&hints->maxHeight);
+				fixSize((CARD16*)&hints->baseWidth, (CARD16*)&hints->baseHeight);
+				debugPropSizeHints(hints);
 			}
 			break;
 		}


### PR DESCRIPTION
Fixed XA_WM_SIZE_HINTS for 64 bit machines. 

Added NoMinSize and NoMaxSize. I've added those specifically for Davinci Resolve because it limits width to 1445 for some reason.

ResizeAll and ResizeWindows are now independent of each other.