### PR TITLE
New features, logging improvements, other internal changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Name                  | Values  | Description
 `NoMinSize`           | `0`/`1` | Boolean - Disable minimum window size restriction.
 `NoMaxSize`           | `0`/`1` | Boolean - Disable maximum window size restriction.
 `NoWindowStackMove`   | `0`/`1` | Boolean - Disable moving windows through the window stack. Prevents moving windows to the top or bottom.
+`NoWMRaise`           | `0`/`1` | Boolean - Filter out `_NET_ACTIVE_WINDOW` requests, prevents asking the window manager to raise windows to the top. 
 `FakeScreenW`/`H`     | Integer | Fake the reported resolution of all X11 screens to the application on X11 handshake. Active when non zero
 `FakeScreenDimW`/`H`  | Integer | Fake the reported dimensions in millimeters of all X11 screens to the application on X11 handshake. Active when non zero
 `MainX`/`Y`           | Integer | The X11 coordinates of your primary monitor (or left-top-most monitor to be used for games)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Name                  | Values  | Description
 `NoResolutionChange`  | `0`/`1` | Boolean - Disable setting screen resolution.
 `NoMinSize`           | `0`/`1` | Boolean - Disable minimum window size restriction.
 `NoMaxSize`           | `0`/`1` | Boolean - Disable maximum window size restriction.
+`NoWindowStackMove`   | `0`/`1` | Boolean - Disable moving windows through the window stack. Prevents moving windows to the top or bottom.
 `FakeScreenW`/`H`     | Integer | Fake the reported resolution of all X11 screens to the application on X11 handshake. Active when non zero
 `FakeScreenDimW`/`H`  | Integer | Fake the reported dimensions in millimeters of all X11 screens to the application on X11 handshake. Active when non zero
 `MainX`/`Y`           | Integer | The X11 coordinates of your primary monitor (or left-top-most monitor to be used for games)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Name                  | Values  | Description
 `NoResolutionChange`  | `0`/`1` | Boolean - Disable setting screen resolution.
 `NoMinSize`           | `0`/`1` | Boolean - Disable minimum window size restriction.
 `NoMaxSize`           | `0`/`1` | Boolean - Disable maximum window size restriction.
+`FakeScreenW`/`H`     | Integer | Fake the reported resolution of all X11 screens to the application on X11 handshake. Active when non zero
+`FakeScreenDimW`/`H`  | Integer | Fake the reported dimensions in millimeters of all X11 screens to the application on X11 handshake. Active when non zero
 `MainX`/`Y`           | Integer | The X11 coordinates of your primary monitor (or left-top-most monitor to be used for games)
 `MainW`/`H`           | Integer | The resolution of your primary monitor (or total resolution of monitors to be used for games)
 `DesktopW`/`H`        | Integer | The resolution of your desktop (all monitors combined)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Name                  | Values  | Description
 `MainW`/`H`           | Integer | The resolution of your primary monitor (or total resolution of monitors to be used for games)
 `DesktopW`/`H`        | Integer | The resolution of your desktop (all monitors combined)
 `Debug`               | Integer | Log level - Non-zero enables debugging output to stderr and `/tmp/hax11.log`
+`LogTimestamp`        | `0`/`1` | Boolean - Enable timestamp logging
 `MSTnX`/`Y`/`W`/`H`   | Integer | Coordinates and sizes of additional MST monitors (`n` can be `2`, `3` or `4`).
 `MapK`/`B`*integer*   | Key     | Map keys or buttons - see below
 

--- a/common.c
+++ b/common.c
@@ -1055,22 +1055,22 @@ static bool handleClientData(X11ConnData* data)
 			CARD16 *w = &dummyW, *h = &dummyH;
 
 			int* ptr = (int*)(data->buf + sz_xConfigureWindowReq);
-			if (req->mask & 0x0001) // x
+			if (req->mask & CWX)
 			{
 				x = (INT16*)ptr;
 				ptr++;
 			}
-			if (req->mask & 0x0002) // y
+			if (req->mask & CWY)
 			{
 				y = (INT16*)ptr;
 				ptr++;
 			}
-			if (req->mask & 0x0004) // width
+			if (req->mask & CWWidth)
 			{
 				w = (CARD16*)ptr;
 				ptr++;
 			}
-			if (req->mask & 0x0008) // height
+			if (req->mask & CWHeight)
 			{
 				h = (CARD16*)ptr;
 				ptr++;
@@ -1080,7 +1080,7 @@ static bool handleClientData(X11ConnData* data)
 			fixCoords(x, y, w, h);
 			log_debug2(" ->              (%dx%d @ %dx%d)\n", *w, *h, *x, *y);
 
-			if ((req->mask & 0x000C) == 0x000C && *w == 0 && *h == 0)
+			if ((req->mask & (CWWidth | CWHeight)) == (CWWidth | CWHeight) && *w == 0 && *h == 0)
 				__builtin_trap();
 
 			break;


### PR DESCRIPTION
Added resolution faking on X11 handshake. Portal 2 (sdl2) was desperately trying to use both monitors as my resolution.

Added `NoWindowStackMove` which filters out window stack move requests. Prevents some applications (Portal 2) from moving to the top for no good reason.

Added `NoWMRaise` which filters out `_NET_ACTIVE_WINDOW` messages. Pretty similar to `NoWindowStackMove`, but instead of filtering X11 requests, it filters messages for the window manager.

Added timestamps to log messages and improved request/response logging.

I'd suggest to not `fopen` on each log and instead just `fflush` because thunar just dies if i'm in /tmp

I also thought about refactoring a lot of the code, is that something you'd be interested in? 

![Screenshot_2024-06-24_03-09-28](https://github.com/CyberShadow/hax11/assets/46835803/0146dcef-4d69-4a9b-a30f-39f27e41c04e)
